### PR TITLE
The email that gets sent now has full details of why recipient got the email

### DIFF
--- a/ckanext/issues/templates/issues/email/new_issue.html
+++ b/ckanext/issues/templates/issues/email/new_issue.html
@@ -1,11 +1,10 @@
-
-A user '{{ user.fullname }}' has raised an issue with one of your datasets on {{ site_title }}.
+On {{ site_title }} a user has raised an issue with one of the datasets from organization '{{ recipient.organization_title }}', for which you are an {{ recipient.capacity }}.' for which you are an {{ capacity }}.
 
 The dataset is: {{ dataset.title }}
 The issue is:
 
-    {{ issue_subject }}
-    "{{ issue.description }}"
+> {{ issue_subject|wordwrap(width=76)|replace('\n', '\n> '|safe) }}
+> {{ issue.description|wordwrap(width=76)|replace('\n', '\n> '|safe) }}
 
 Please correct the problem or add an initial comment about the issue at: {{ h.url_for('issues_show', dataset_id=dataset.name, issue_number=issue.number, qualified=True) }}. Once the issue has been resolved, click 'Close issue'.
 
@@ -17,4 +16,4 @@ The {{ site_title }} team
 
 Issue: {{ h.url_for('issues_show', dataset_id=dataset.name, issue_number=issue.number, qualified=True) }}
 Dataset: {{ h.url_for('dataset_read', id=dataset.name, qualified=True) }}
-
+User: {{ user.fullname or user.name }}

--- a/ckanext/issues/tests/logic/action/test_issue.py
+++ b/ckanext/issues/tests/logic/action/test_issue.py
@@ -7,6 +7,7 @@ from ckan.plugins import toolkit
 from ckanext.issues.tests import factories as issue_factories
 from ckanext.issues.model import Issue, IssueComment, AbuseStatus
 from ckanext.issues.tests.helpers import ClearOnTearDownMixin
+from ckanext.issues.logic.action.action import _get_recipients
 
 from ckan import model
 
@@ -157,6 +158,20 @@ class TestIssueNew(ClearOnTearDownMixin):
         )
         issue_object = Issue.get(issue_create_result['id'])
         assert_equals('visible', issue_object.visibility)
+
+    def test_get_recipients(self):
+        user = factories.User()
+        org = factories.Organization(user=user)
+        dataset = factories.Dataset(owner_org=org['id'])
+        dataset_obj = model.Package.get(dataset['id'])
+
+        recip = _get_recipients(context={}, dataset=dataset_obj)
+
+        assert_equals(len(recip), 1)
+        assert_equals(recip[0]['user_id'], user['id'])
+        assert_equals(recip[0]['capacity'], 'Admin')
+        assert_equals(recip[0]['organization_name'], org['name'])
+        assert_equals(recip[0]['organization_title'], org['title'])
 
 
 class TestIssueComment(ClearOnTearDownMixin):


### PR DESCRIPTION
The template gets new dict 'recipient' with details of the organization and capacity in which they were picked for the email.