### PR TITLE
Format the unicode string in helpers.get_issue_subject

### DIFF
--- a/ckanext/issues/lib/helpers.py
+++ b/ckanext/issues/lib/helpers.py
@@ -200,10 +200,9 @@ def get_issue_subject(issue):
     site_title = get_site_title()
     dataset = model.Package.get(issue['dataset_id'])
     return toolkit._(
-        '[{site_title} Issue] {dataset}'.format(
+        '[{site_title} Issue] {dataset}').format(
             site_title=site_title,
             dataset=dataset.title,
-        )
     )
 
 


### PR DESCRIPTION
I.e. apply .format() on the result of toolkit._() instead of the other way
arround.

This fixes a UnicodeDecodeError that may occur if, for instance, dataset.title
has non-ASCII characters.